### PR TITLE
GITHUB_TOKEN read-only change: Include permission block

### DIFF
--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   setupBackport:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     if: github.event.issue.pull_request != '' && startswith(github.event.comment.body, '@vs-mobiletools-engineering-service2 backport')
     outputs:
       target_branch: ${{ steps.parse_comment.outputs.target_branch }}

--- a/.github/workflows/rebase-trigger.yml
+++ b/.github/workflows/rebase-trigger.yml
@@ -7,6 +7,14 @@ on:
 jobs:
   launchBackportBuild:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
+
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@vs-mobiletools-engineering-service2 rebase')
 
     steps:

--- a/workflow-templates/backport-trigger/backport-trigger.yml
+++ b/workflow-templates/backport-trigger/backport-trigger.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   setupBackport:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     if: github.event.issue.pull_request != '' && startswith(github.event.comment.body, '@vs-mobiletools-engineering-service2 backport')
     outputs:
       target_branch: ${{ steps.parse_comment.outputs.target_branch }}


### PR DESCRIPTION
Related work item: VS #[1943359](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1943359)

Related PR: https://github.com/xamarin/backport-bot-action/pull/21

In anticipation of the GitHub change to make GITHUB_TOKEN read-only on 2024-02-01, add a permission block to the GitHub action yaml files per the following guidance:
https://docs.opensource.microsoft.com/github/apps/permission-changes/

Available permissions are documented here:
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
